### PR TITLE
Update to use the official OSGi dependencies

### DIFF
--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -74,22 +74,22 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.annotation</artifactId>
+            <artifactId>osgi.annotation</artifactId>
+            <version>6.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
             <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>6.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
             <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.jaxrs.whiteboard</artifactId>
+            <artifactId>org.osgi.service.jaxrs</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
The OSGi Alliance published spec jars are all named osgi.XXXX. Also the JAX-RS Whiteboard artifact has been renamed.