### PR TITLE
Flatten the CXF and Aries dependencies into the Whiteboard JAR

### DIFF
--- a/jax-rs.whiteboard/bnd.bnd
+++ b/jax-rs.whiteboard/bnd.bnd
@@ -51,13 +51,7 @@ Import-Package:\
     *
 
 -includeresource:\
-    lib/component-dsl.jar=org.apache.aries.component-dsl.component-dsl-*.jar;lib:=true,\
-    lib/cxf-core.jar=cxf-core-*.jar;lib:=true,\
-    lib/cxf-rt-frontend-jaxrs.jar=cxf-rt-frontend-jaxrs-*.jar;lib:=true,\
-    lib/cxf-rt-rs-client.jar=cxf-rt-rs-client-*.jar;lib:=true,\
-    lib/cxf-rt-rs-sse.jar=cxf-rt-rs-sse-*.jar;lib:=true,\
-    lib/cxf-rt-transports-http.jar=cxf-rt-transports-http-*.jar;lib:=true,\
-    lib/cxf-tools-common.jar=cxf-tools-common-*.jar;lib:=true,\
+    @org.apache.aries.jax.rs.cxf.repackage-*.jar,\
     lib/stax2-api.jar=stax2-api-*.jar;lib:=true,\
     lib/woodstox-core.jar=woodstox-core-*.jar;lib:=true,\
     lib/xmlschema-core.jar=xmlschema-core-*.jar;lib:=true

--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -95,6 +95,11 @@
             <artifactId>org.osgi.util.function</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.aries.jax.rs.cxf.repackage</groupId>
+            <artifactId>org.apache.aries.jax.rs.cxf.repackage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.2</version>

--- a/org.apache.aries.jax.rs.cxf.repackage/pom.xml
+++ b/org.apache.aries.jax.rs.cxf.repackage/pom.xml
@@ -1,0 +1,110 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+    <parent>
+      <groupId>org.apache.aries.jax.rs</groupId>
+      <artifactId>org.apache.aries.jax.rs</artifactId>
+      <version>1.0.5-SNAPSHOT</version>
+    </parent>
+  
+    <groupId>org.apache.aries.jax.rs.cxf.repackage</groupId>
+    <artifactId>org.apache.aries.jax.rs.cxf.repackage</artifactId>
+    <description>This project extracts and repackages CXF so that the whiteboard can be more easily built</description>
+    <name>Aries JAX-RS Whiteboard CXF dependency repackaging</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.aries.component-dsl</groupId>
+            <artifactId>org.apache.aries.component-dsl.component-dsl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-sse</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-tools-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                
+                <executions>
+                    <execution>
+                        <id>extract-classes</id>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                           <includes>**/*.class,**/Messages.properties,META-INF/services/*,org/apache/cxf/version/version.properties</includes>
+                           <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                           <markersDirectory>${project.build.directory}/dependency-maven-plugin-markers-classes</markersDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>extract-bus-extensions</id>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                           <includeGroupIds>org.apache.cxf</includeGroupIds>
+                           <includes>META-INF/cxf/bus-extensions.txt</includes>
+                           <outputDirectory>${project.build.directory}/cxf-bus</outputDirectory>
+                           <useSubDirectoryPerArtifact>true</useSubDirectoryPerArtifact>
+                           <markersDirectory>${project.build.directory}/dependency-maven-plugin-markers-extensions</markersDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                	<excludeTransitive>true</excludeTransitive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-merged-extensions</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <concat destfile="${project.build.outputDirectory}/META-INF/cxf/bus-extensions.txt"
+                                        fixlastline="true">
+                                    <fileset dir="${project.build.directory}/cxf-bus">
+                                        <include name="**/bus-extensions.txt"></include>
+                                    </fileset>
+                                    <filterchain>
+                                        <tokenfilter> <trim/> </tokenfilter>
+                                        <tokenfilter> <ignoreblank/> </tokenfilter>
+                                    </filterchain>
+                                </concat>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/org.apache.aries.jax.rs.cxf.repackage/src/main/resources/META-INF/MANIFEST.MF
+++ b/org.apache.aries.jax.rs.cxf.repackage/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Manifest-Version: 1.0

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>jax-rs.itests-fragment</module>
         <module>jax-rs.itests</module>
         <module>jax-rs.features</module>
+        <module>org.apache.aries.jax.rs.cxf.repackage</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This should improve performance a little (nested jars are slower to search) and make the resulting code easier to debug.

Signed-off-by: Tim Ward <timothyjward@apache.org>