### PR TITLE
Separate component dsl

### DIFF
--- a/integrations/cxf-jettison/cxf-jettison-itest/itest.bndrun
+++ b/integrations/cxf-jettison/cxf-jettison-itest/itest.bndrun
@@ -48,6 +48,7 @@
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.jaxb.json.cxf-jettison;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.jaxb.json.cxf-jettison-itest;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\

--- a/integrations/cxf-jettison/cxf-jettison-jaxrs/bnd.bnd
+++ b/integrations/cxf-jettison/cxf-jettison-jaxrs/bnd.bnd
@@ -14,5 +14,3 @@
 #    KIND, either express or implied.  See the License for the
 #    specific language governing permissions and limitations
 #    under the License.
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/integrations/jackson/jackson-itest/itest.bndrun
+++ b/integrations/jackson/jackson-itest/itest.bndrun
@@ -53,6 +53,7 @@
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.jackson;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.jackson.itest;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\

--- a/integrations/jackson/jackson-jaxrs/bnd.bnd
+++ b/integrations/jackson/jackson-jaxrs/bnd.bnd
@@ -14,5 +14,3 @@
 #    KIND, either express or implied.  See the License for the
 #    specific language governing permissions and limitations
 #    under the License.
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/integrations/openapi/openapi-itest/itest.bndrun
+++ b/integrations/openapi/openapi-itest/itest.bndrun
@@ -63,6 +63,7 @@
 	io.swagger.core.v3.swagger-models;version='[2.1.7,2.1.8)',\
 	jakarta.validation.jakarta.validation-api;version='[2.0.2,2.0.3)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.openapi.itest;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.openapi.resource;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\

--- a/integrations/openapi/openapi-resource/bnd.bnd
+++ b/integrations/openapi/openapi-resource/bnd.bnd
@@ -16,5 +16,3 @@
 #    under the License.
 
 Export-Package: org.apache.aries.jax.rs.openapi;version=${openapi.version}
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/integrations/rest-management/rest-management-itest/itest.bndrun
+++ b/integrations/rest-management/rest-management-itest/itest.bndrun
@@ -85,6 +85,7 @@
 	net.javacrumbs.json-unit.json-unit-json-path;version='[2.25.0,2.25.1)',\
 	net.minidev.accessors-smart;version='[1.2.0,1.2.1)',\
 	net.minidev.json-smart;version='[2.3.0,2.3.1)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.openapi.resource;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.rest.management;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.rest.management.itest;version='[2.0.0,2.0.1)',\

--- a/integrations/rest-management/rest-management/bnd.bnd
+++ b/integrations/rest-management/rest-management/bnd.bnd
@@ -20,5 +20,3 @@ Import-Package: \
 	javax.xml.bind.annotation;version="[2.3.0,3)",\
 	javax.xml.bind.annotation.adapters;version="[2.3.0,3)",\
 	*
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/integrations/shiro/shiro-authc/bnd.bnd
+++ b/integrations/shiro/shiro-authc/bnd.bnd
@@ -19,5 +19,3 @@
 # Support is not an OSGi bundle
 
 -includepackage: org.apache.shiro.web.jaxrs;version=${shiro.version}
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/integrations/shiro/shiro-authz/bnd.bnd
+++ b/integrations/shiro/shiro-authz/bnd.bnd
@@ -19,5 +19,3 @@
 # Support is not an OSGi bundle
 
 -includepackage: org.apache.shiro.web.jaxrs;version=${shiro.version}
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/integrations/shiro/shiro-itest/itest.bndrun
+++ b/integrations/shiro/shiro-itest/itest.bndrun
@@ -48,6 +48,7 @@
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.shiro.authc;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.shiro.authz;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.shiro.itest;version='[2.0.0,2.0.1)',\

--- a/jax-rs.example/aries-jaxrs-whiteboard-example.bndrun
+++ b/jax-rs.example/aries-jaxrs-whiteboard-example.bndrun
@@ -51,6 +51,7 @@
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.example;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.2,1.3.3)',\

--- a/jax-rs.example/aries-jaxrs-whiteboard-only.bndrun
+++ b/jax-rs.example/aries-jaxrs-whiteboard-only.bndrun
@@ -50,6 +50,7 @@
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.2,1.3.3)',\
 	org.apache.cxf.cxf-core;version='[3.4.3,3.4.4)',\

--- a/jax-rs.itests/itest.bndrun
+++ b/jax-rs.itests/itest.bndrun
@@ -52,6 +52,7 @@
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.itests;version='[2.0.0,2.0.1)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.2,1.3.3)',\

--- a/jax-rs.whiteboard/bnd.bnd
+++ b/jax-rs.whiteboard/bnd.bnd
@@ -16,5 +16,3 @@
 #    under the License.
 
 Provide-Capability: osgi.implementation;osgi.implementation="aries.jax-rs";version:Version="${Bundle-Version}"
-
--conditionalpackage: org.apache.aries.component.dsl.*

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,6 @@
                 <groupId>org.apache.aries.component-dsl</groupId>
                 <artifactId>org.apache.aries.component-dsl.component-dsl</artifactId>
                 <version>${dsl.version}</version>
-                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.osgi</groupId>


### PR DESCRIPTION
This removes all the embedded usages of component-dsl and uses it like a regular bundle (I feel this simplifies maintenance and reduces the issues with use cases like native image.)