### PR TITLE
Bump johnzon.version from 1.2.10 to 1.2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <geronimo.jaxrs.version>1.1</geronimo.jaxrs.version>
         <geronimo.json.version>1.5</geronimo.json.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <johnzon.version>1.2.10</johnzon.version>
+        <johnzon.version>1.2.11</johnzon.version>
         <jackson.version>2.12.3</jackson.version>
         <jaxb.version>2.3.3</jaxb.version>
         <jettison.version>1.4.1</jettison.version>


### PR DESCRIPTION
Bumps `johnzon.version` from 1.2.10 to 1.2.11.

Updates `johnzon-core` from 1.2.10 to 1.2.11

Updates `johnzon-mapper` from 1.2.10 to 1.2.11

Signed-off-by: dependabot[bot] <support@github.com>