### PR TITLE
Make the JAX-RS whiteboard easily resolvable with minimal pom dependencies

### DIFF
--- a/integrations/cxf-jettison/cxf-jettison-itest/bnd.bnd
+++ b/integrations/cxf-jettison/cxf-jettison-itest/bnd.bnd
@@ -21,3 +21,6 @@ Test-Cases: \
 	${classes;CONCRETE;ANNOTATED;org.junit.Test}
 
 Require-Capability: osgi.service;filter:="(objectClass=org.osgi.service.cm.ConfigurationAdmin)"
+
+# We have a wide range for JAX-B to run on Java 8
+Import-Package: javax.xml.bind.*;version="${range;[0,+)}", *

--- a/integrations/cxf-jettison/cxf-jettison-itest/itest.bndrun
+++ b/integrations/cxf-jettison/cxf-jettison-itest/itest.bndrun
@@ -25,13 +25,19 @@
 	org.slf4j.event;version=${slf4j.version},\
 	org.slf4j.helpers;version=${slf4j.version},\
 	org.slf4j.spi;version=${slf4j.version}
-
+	
 -runfw: org.eclipse.osgi
 
 -resolve.effective: resolve, active
 
--runrequires: \
+java.8.reqs: \
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.jaxb.json.cxf-jettison-itest)'
+
+java.9.plus.reqs: \
+	${java.8.reqs},\
+	osgi.identity;filter:='(osgi.identity=com.sun.xml.bind.jaxb-osgi)'
+
+-runrequires: ${if;${is;${-runee};JavaSE-1.8};${java.8.reqs};${java.9.plus.reqs}}
 
 -runsystemcapabilities: ${native_capability}
 
@@ -46,8 +52,6 @@
 
 -runbundles: \
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
-	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.jaxb.json.cxf-jettison;version='[2.0.1,2.0.2)',\
 	org.apache.aries.jax.rs.jaxb.json.cxf-jettison-itest;version='[2.0.1,2.0.2)',\
@@ -60,8 +64,8 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
@@ -72,6 +76,10 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	stax2-api;version='[4.2.1,4.2.2)'
+
+blacklist.java.8.jaxb: osgi.identity;filter:=(osgi.identity=jakarta.xml.bind-api)
+
+-runblacklist: ${if;${is;${-runee};JavaSE-1.8};${blacklist.java.8.jaxb}}
 
 -runstartlevel: \
 	order=sortbynameversion,\

--- a/integrations/cxf-jettison/cxf-jettison-itest/pom.xml
+++ b/integrations/cxf-jettison/cxf-jettison-itest/pom.xml
@@ -66,6 +66,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.aries.jax.rs</groupId>
             <artifactId>org.apache.aries.jax.rs.jaxb.json.cxf-jettison</artifactId>
             <version>${project.version}</version>

--- a/integrations/cxf-jettison/cxf-jettison-jaxrs/bnd.bnd
+++ b/integrations/cxf-jettison/cxf-jettison-jaxrs/bnd.bnd
@@ -14,3 +14,6 @@
 #    KIND, either express or implied.  See the License for the
 #    specific language governing permissions and limitations
 #    under the License.
+
+# We have a wide range for JAX-B to run on Java 8
+Import-Package: javax.xml.bind.*;version="${range;[0,+)}", *

--- a/integrations/cxf-jettison/cxf-jettison-jaxrs/pom.xml
+++ b/integrations/cxf-jettison/cxf-jettison-jaxrs/pom.xml
@@ -42,6 +42,10 @@
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integrations/jackson/jackson-itest/itest.bndrun
+++ b/integrations/jackson/jackson-itest/itest.bndrun
@@ -30,8 +30,14 @@
 
 -resolve.effective: resolve, active
 
--runrequires: \
+java.8.reqs: \
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.jackson.itest)'
+
+java.9.plus.reqs: \
+	${java.8.reqs},\
+	osgi.identity;filter:='(osgi.identity=com.sun.xml.bind.jaxb-osgi)'
+
+-runrequires: ${if;${is;${-runee};JavaSE-1.8};${java.8.reqs};${java.9.plus.reqs}}
 
 -runsystemcapabilities: ${native_capability}
 -runproperties: \
@@ -51,7 +57,6 @@
 	com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider;version='[2.12.3,2.12.4)',\
 	com.fasterxml.jackson.module.jackson-module-jaxb-annotations;version='[2.12.3,2.12.4)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.jackson;version='[2.0.1,2.0.2)',\
@@ -64,8 +69,8 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\

--- a/integrations/jackson/jackson-jaxrs/pom.xml
+++ b/integrations/jackson/jackson-jaxrs/pom.xml
@@ -36,16 +36,6 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.aries.component-dsl</groupId>

--- a/integrations/openapi/openapi-itest/itest.bndrun
+++ b/integrations/openapi/openapi-itest/itest.bndrun
@@ -33,9 +33,15 @@
 
 -resolve.effective: resolve, active
 
--runrequires: \
+java.8.reqs: \
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.openapi.resource)',\
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.openapi.itest)'
+
+java.9.plus.reqs: \
+	${java.8.reqs},\
+	osgi.identity;filter:='(osgi.identity=com.sun.xml.bind.jaxb-osgi)'
+
+-runrequires: ${if;${is;${-runee};JavaSE-1.8};${java.8.reqs};${java.9.plus.reqs}}
 
 -runsystemcapabilities: ${native_capability}
 -runproperties: \
@@ -54,7 +60,6 @@
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.12.1,2.12.2)',\
 	com.fasterxml.jackson.datatype.jackson-datatype-jsr310;version='[2.12.1,2.12.2)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	io.github.classgraph.classgraph;version='[4.8.95,4.8.96)',\
 	io.swagger.core.v3.swagger-annotations;version='[2.1.9,2.1.10)',\
 	io.swagger.core.v3.swagger-core;version='[2.1.9,2.1.10)',\
@@ -75,8 +80,8 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\

--- a/integrations/rest-management/rest-management-itest/bnd.bnd
+++ b/integrations/rest-management/rest-management-itest/bnd.bnd
@@ -18,3 +18,6 @@
 Bundle-Description: Integration Test bundle for the REST Management integration
 
 Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.jupiter.api.Test}
+
+# We have a wide range for JAX-B to run on Java 8
+Import-Package: javax.xml.bind.*;version="${range;[0,+)}", *

--- a/integrations/rest-management/rest-management-itest/itest.bndrun
+++ b/integrations/rest-management/rest-management-itest/itest.bndrun
@@ -22,12 +22,16 @@
     ch.qos.logback.core,\
     org.apache.felix.logback,\
     slf4j.api
+    
+jaxb.export: javax.xml.bind;javax.xml.bind.annotation;javax.xml.bind.helpers;javax.xml.bind.util;version=2.3.0
+
 -runsystempackages: \
     org.slf4j;version=${slf4j.version},\
     org.slf4j.event;version=${slf4j.version},\
     org.slf4j.helpers;version=${slf4j.version},\
     org.slf4j.spi;version=${slf4j.version},\
-    com.sun.net.httpserver
+    com.sun.net.httpserver,\
+    ${if;${is;${-runee};JavaSE-1.8};${jaxb.export}}
 
 -runfw: org.eclipse.osgi
 
@@ -36,13 +40,19 @@
 
 -resolve.effective: resolve, active
 
--runrequires: \
-    osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.rest.management)',\
+java.8.reqs: \
+	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.rest.management)',\
     osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.rest.management.itest)',\
     osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)',\
     osgi.identity;filter:='(osgi.identity=org.apache.johnzon.mapper)',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher'
+
+java.9.plus.reqs: \
+	${java.8.reqs},\
+	osgi.identity;filter:='(osgi.identity=com.sun.xml.bind.jaxb-osgi)'
+
+-runrequires: ${if;${is;${-runee};JavaSE-1.8};${java.8.reqs};${java.9.plus.reqs}}
 
 -runsystemcapabilities: ${native_capability}
 -runproperties: \
@@ -65,8 +75,6 @@
 	com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider;version='[2.12.1,2.12.2)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.jayway.jsonpath.json-path;version='[2.4.0,2.4.1)',\
-	com.sun.istack.commons-runtime;version='[3.0.11,3.0.12)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	io.github.classgraph.classgraph;version='[4.8.95,4.8.96)',\
 	io.swagger.core.v3.swagger-annotations;version='[2.1.9,2.1.10)',\
 	io.swagger.core.v3.swagger-core;version='[2.1.9,2.1.10)',\
@@ -74,12 +82,11 @@
 	io.swagger.core.v3.swagger-jaxrs2;version='[2.1.9,2.1.10)',\
 	io.swagger.core.v3.swagger-models;version='[2.1.9,2.1.10)',\
 	jakarta.validation.jakarta.validation-api;version='[2.0.2,2.0.3)',\
-	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
-	junit-jupiter-api;version='[5.7.1,5.7.2)',\
-	junit-jupiter-engine;version='[5.7.1,5.7.2)',\
-	junit-platform-commons;version='[1.7.1,1.7.2)',\
-	junit-platform-engine;version='[1.7.1,1.7.2)',\
-	junit-platform-launcher;version='[1.7.1,1.7.2)',\
+	junit-jupiter-api;version='[5.7.2,5.7.3)',\
+	junit-jupiter-engine;version='[5.7.2,5.7.3)',\
+	junit-platform-commons;version='[1.7.2,1.7.3)',\
+	junit-platform-engine;version='[1.7.2,1.7.3)',\
+	junit-platform-launcher;version='[1.7.2,1.7.3)',\
 	net.javacrumbs.json-unit.json-unit-assertj;version='[2.25.0,2.25.1)',\
 	net.javacrumbs.json-unit.json-unit-core;version='[2.25.0,2.25.1)',\
 	net.javacrumbs.json-unit.json-unit-json-path;version='[2.25.0,2.25.1)',\
@@ -98,11 +105,11 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
 	org.apache.felix.gogo.command;version='[1.1.2,1.1.3)',\
 	org.apache.felix.gogo.runtime;version='[1.1.4,1.1.5)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
@@ -124,6 +131,10 @@
 	org.xmlunit.xmlunit-core;version='[2.8.2,2.8.3)',\
 	org.yaml.snakeyaml;version='[1.27.0,1.27.1)',\
 	stax2-api;version='[4.2.1,4.2.2)'
+
+blacklist.java.8.jaxb: osgi.identity;filter:='(osgi.identity=jakarta.xml.bind-api)'
+
+-runblacklist: ${if;${is;${-runee};JavaSE-1.8};${blacklist.java.8.jaxb}}
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/integrations/rest-management/rest-management/bnd-java-9-plus.bnd
+++ b/integrations/rest-management/rest-management/bnd-java-9-plus.bnd
@@ -15,14 +15,6 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
-# Different behaviour needed on JDK 9 and higher
 Multi-Release: true
 
-# The Sun JAX-B impl is complicated because of Java 8. Optional on Java 8 as we can use the JDK version,
-# and a broad range for the JAX-B API
-Import-Package: \
-    com.sun.xml.bind.annotation;resolution:=optional, \
-    javax.xml.bind.*;version="${range;[0,+)}", \
-    *
-
-Provide-Capability: osgi.implementation;osgi.implementation="aries.jax-rs";version:Version="${Bundle-Version}"
+# No need to customise the import for JAX-B

--- a/integrations/rest-management/rest-management/bnd.bnd
+++ b/integrations/rest-management/rest-management/bnd.bnd
@@ -15,8 +15,7 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
-Import-Package: \
-	javax.xml.bind;version="[2.3.0,3)",\
-	javax.xml.bind.annotation;version="[2.3.0,3)",\
-	javax.xml.bind.annotation.adapters;version="[2.3.0,3)",\
-	*
+Multi-Release: true
+
+# We have a wide range for JAX-B to run on Java 8
+Import-Package: javax.xml.bind.*;version="${range;[0,+)}", *

--- a/integrations/rest-management/rest-management/pom.xml
+++ b/integrations/rest-management/rest-management/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>org.apache.aries.component-dsl.component-dsl</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.aries.jax.rs</groupId>
             <artifactId>org.apache.aries.jax.rs.openapi.resource</artifactId>
             <version>${project.version}</version>

--- a/integrations/rest-management/rest-management/pom.xml
+++ b/integrations/rest-management/rest-management/pom.xml
@@ -59,6 +59,21 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                
+                <executions>
+                    <execution>
+                        <id>java-9-plus</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <bndfile>bnd-java-9-plus.bnd</bndfile>
+                            <manifestPath>${project.build.outputDirectory}/META-INF/versions/9/OSGI-INF/MANIFEST.MF</manifestPath>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/integrations/shiro/shiro-itest/itest.bndrun
+++ b/integrations/shiro/shiro-itest/itest.bndrun
@@ -47,7 +47,11 @@
 -runbundles: \
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.activation-api;version='[1.2.2,1.2.3)',\
+	jakarta.annotation-api;version='[1.3.5,1.3.6)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	jakarta.xml.soap-api;version='[1.4.2,1.4.3)',\
+	jakarta.xml.ws-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.shiro.authc;version='[2.0.1,2.0.2)',\
 	org.apache.aries.jax.rs.shiro.authz;version='[2.0.1,2.0.2)',\
@@ -60,18 +64,17 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
 	org.apache.felix.gogo.command;version='[1.1.2,1.1.3)',\
 	org.apache.felix.gogo.runtime;version='[1.1.4,1.1.5)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
-	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
 	org.apache.servicemix.bundles.junit;version='[4.13.0,4.13.1)',\
 	org.apache.shiro.core;version='[1.7.1,1.7.2)',\
-	org.apache.shiro.lang;version='[1.7.1,1.7.2)',\
 	org.apache.ws.xmlschema.core;version='[2.2.5,2.2.6)',\
+	org.glassfish.jaxb.runtime;version='[2.3.3,2.3.4)',\
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\

--- a/integrations/shiro/shiro-itest/itest.bndrun
+++ b/integrations/shiro/shiro-itest/itest.bndrun
@@ -30,9 +30,15 @@
 
 -resolve.effective: resolve, active
 
--runrequires: \
+java.8.reqs: \
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.shiro.itest)',\
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
+
+java.9.plus.reqs: \
+	${java.8.reqs},\
+	osgi.identity;filter:='(osgi.identity=com.sun.xml.bind.jaxb-osgi)'
+
+-runrequires: ${if;${is;${-runee};JavaSE-1.8};${java.8.reqs};${java.9.plus.reqs}}
 
 -runsystemcapabilities: ${native_capability}
 
@@ -46,12 +52,6 @@
 
 -runbundles: \
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
-	jakarta.activation-api;version='[1.2.2,1.2.3)',\
-	jakarta.annotation-api;version='[1.3.5,1.3.6)',\
-	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
-	jakarta.xml.soap-api;version='[1.4.2,1.4.3)',\
-	jakarta.xml.ws-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.shiro.authc;version='[2.0.1,2.0.2)',\
 	org.apache.aries.jax.rs.shiro.authz;version='[2.0.1,2.0.2)',\
@@ -70,15 +70,19 @@
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
 	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
+	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
 	org.apache.servicemix.bundles.junit;version='[4.13.0,4.13.1)',\
 	org.apache.shiro.core;version='[1.7.1,1.7.2)',\
 	org.apache.ws.xmlschema.core;version='[2.2.5,2.2.6)',\
-	org.glassfish.jaxb.runtime;version='[2.3.3,2.3.4)',\
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	stax2-api;version='[4.2.1,4.2.2)'
+
+blacklist.java.8.jaxb: osgi.identity;filter:=(osgi.identity=jakarta.xml.bind-api)
+
+-runblacklist: ${if;${is;${-runee};JavaSE-1.8};${blacklist.java.8.jaxb}}
 
 -runstartlevel: \
 	order=sortbynameversion,\

--- a/jax-rs.example/aries-jaxrs-whiteboard-example.bndrun
+++ b/jax-rs.example/aries-jaxrs-whiteboard-example.bndrun
@@ -49,8 +49,6 @@
 
 -runbundles: \
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
-	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.example;version='[2.0.1,2.0.2)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.1,2.0.2)',\
@@ -61,11 +59,11 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
 	org.apache.felix.gogo.command;version='[1.1.2,1.1.3)',\
 	org.apache.felix.gogo.runtime;version='[1.1.4,1.1.5)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\

--- a/jax-rs.example/aries-jaxrs-whiteboard-only.bndrun
+++ b/jax-rs.example/aries-jaxrs-whiteboard-only.bndrun
@@ -48,8 +48,6 @@
 
 -runbundles: \
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
-	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.1,2.0.2)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.3,1.3.4)',\
@@ -59,8 +57,8 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\

--- a/jax-rs.example/pom.xml
+++ b/jax-rs.example/pom.xml
@@ -80,21 +80,55 @@
         </plugins>
     </build>
     <dependencies>
+        <!-- These compile dependencies are used directly by the example resource -->
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jaxrs_2.1_spec</artifactId>
+        </dependency>
 
+
+        <!-- This runtime dependency is a Declarative Services implementation, 
+        used to publish the example resource as an OSGi service-->
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- This runtime dependency is the Aries JAX-RS whiteboard, used to
+        provide a JAX-RS runtime for hosting the Foo service  -->
         <dependency>
             <groupId>org.apache.aries.jax.rs</groupId>
             <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
             <version>${project.version}</version>
-            <scope>runtime</scope>
+        </dependency>
+        
+        <!-- These runtime dependencies are needed to run the JAX-RS whiteboard,
+         * Felix Http Jetty provides an HTTP whiteboard implementation 
+         * Felix Configuration Admin provides configuration support, 
+         * Eclipse Equinox is the OSGi framework implementation 
+         
+         You can choose different implementations if you prefer.
+         -->
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/jax-rs.itests/bnd.bnd
+++ b/jax-rs.itests/bnd.bnd
@@ -18,3 +18,6 @@
 Bundle-Description: Integration Test bundle for the JAX-RS extender
 
 Test-Cases: ${classes;CONCRETE;ANNOTATED;org.junit.Test}
+
+# We have a wide range for JAX-B to run on Java 8
+Import-Package: javax.xml.bind.*;version="${range;[0,+)}", *

--- a/jax-rs.itests/itest.bndrun
+++ b/jax-rs.itests/itest.bndrun
@@ -33,9 +33,15 @@
 
 -resolve.effective: resolve, active
 
--runrequires: \
+java.8.reqs: \
 	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.itests)',\
 	osgi.identity;filter:='(osgi.identity=org.apache.felix.gogo.command)'
+
+java.9.plus.reqs: \
+	${java.8.reqs},\
+	osgi.identity;filter:='(osgi.identity=com.sun.xml.bind.jaxb-osgi)'
+
+-runrequires: ${if;${is;${-runee};JavaSE-1.8};${java.8.reqs};${java.9.plus.reqs}}
 
 -runsystemcapabilities: ${native_capability}
 -runproperties: \
@@ -50,8 +56,6 @@
 -runbundles: \
 	assertj-core;version='[3.19.0,3.19.1)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.4,6.2.5)',\
-	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
-	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.jax.rs.itests;version='[2.0.1,2.0.2)',\
 	org.apache.aries.jax.rs.whiteboard;version='[2.0.1,2.0.2)',\
@@ -63,11 +67,11 @@
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-security;version='[3.4.3,3.4.4)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.4.3,3.4.4)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
+	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
 	org.apache.felix.gogo.command;version='[1.1.2,1.1.3)',\
 	org.apache.felix.gogo.runtime;version='[1.1.4,1.1.5)',\
 	org.apache.felix.gogo.shell;version='[1.1.4,1.1.5)',\
-	org.apache.felix.http.jetty;version='[4.1.6,4.1.7)',\
+	org.apache.felix.http.jetty;version='[4.1.8,4.1.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.geronimo.specs.geronimo-annotation_1.3_spec;version='[1.3.0,1.3.1)',\
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec;version='[1.1.0,1.1.1)',\
@@ -77,6 +81,11 @@
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
 	stax2-api;version='[4.2.1,4.2.2)'
+	
+	
+blacklist.java.8.jaxb: osgi.identity;filter:='(osgi.identity=jakarta.xml.bind-api)'
+
+-runblacklist: ${if;${is;${-runee};JavaSE-1.8};${blacklist.java.8.jaxb}}
 
 -runstartlevel: \
 	order=sortbynameversion,\

--- a/jax-rs.itests/pom.xml
+++ b/jax-rs.itests/pom.xml
@@ -64,6 +64,36 @@
                     </bndruns>
                 </configuration>
             </plugin>
+            <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-invoker-plugin</artifactId>
+				<version>3.2.2</version>
+				<configuration>
+					<cloneProjectsTo>${project.build.directory}/integration-test/projects</cloneProjectsTo>
+					<cloneClean>true</cloneClean>
+					<projectsDirectory>src/test/resources/integration-test</projectsDirectory>
+					<streamLogs>true</streamLogs>
+					<useLocalRepository>true</useLocalRepository>
+					<scriptVariables>
+						<bndVersion>${project.version}</bndVersion>
+					</scriptVariables>
+					<mavenOpts>${mavenOpts}</mavenOpts>
+					<goals>
+						<goal>--no-transfer-progress</goal>
+						<goal>package</goal>
+					</goals>
+					
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>install</goal>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
     <dependencies>

--- a/jax-rs.itests/src/test/resources/integration-test/whiteboard-resolve-test/java-11.bndrun
+++ b/jax-rs.itests/src/test/resources/integration-test/whiteboard-resolve-test/java-11.bndrun
@@ -1,0 +1,7 @@
+-runfw: org.eclipse.osgi
+
+-resolve.effective: resolve, active
+
+-runrequires: \
+	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.whiteboard)'
+-runee: JavaSE-11

--- a/jax-rs.itests/src/test/resources/integration-test/whiteboard-resolve-test/java-8.bndrun
+++ b/jax-rs.itests/src/test/resources/integration-test/whiteboard-resolve-test/java-8.bndrun
@@ -1,0 +1,7 @@
+-runfw: org.eclipse.osgi
+
+-resolve.effective: resolve, active
+
+-runrequires: \
+	osgi.identity;filter:='(osgi.identity=org.apache.aries.jax.rs.whiteboard)'
+-runee: JavaSE-1.8

--- a/jax-rs.itests/src/test/resources/integration-test/whiteboard-resolve-test/pom.xml
+++ b/jax-rs.itests/src/test/resources/integration-test/whiteboard-resolve-test/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.apache.aries.jax.rs.itests</groupId>
+	<artifactId>whiteboard-resolve-test</artifactId>
+	<version>0.0.1</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	</properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.aries.jax.rs</groupId>
+            <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
+            <version>@project.version@</version>
+            <scope>runtime</scope>
+        </dependency>
+
+		<!-- Users provide their own Config Admin, Http Whiteboard, and framework -->
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.http.jetty</artifactId>
+            <version>@felix.http.jetty.version@</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+            <version>@felix.configadmin.version@</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>@eclipse.osgi.version@</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-resolver-maven-plugin</artifactId>
+				<version>@bnd.version@</version>
+				<configuration>
+					<failOnChanges>false</failOnChanges>
+					<writeOnChanges>false</writeOnChanges>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>resolve</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/jax-rs.whiteboard/bnd-java-9-plus.bnd
+++ b/jax-rs.whiteboard/bnd-java-9-plus.bnd
@@ -15,14 +15,9 @@
 #    specific language governing permissions and limitations
 #    under the License.
 
-# Different behaviour needed on JDK 9 and higher
 Multi-Release: true
 
-# The Sun JAX-B impl is complicated because of Java 8. Optional on Java 8 as we can use the JDK version,
-# and a broad range for the JAX-B API
-Import-Package: \
-    com.sun.xml.bind.annotation;resolution:=optional, \
-    javax.xml.bind.*;version="${range;[0,+)}", \
-    *
+# No customisation needed for JAX-B, just use the 2.3 impl that is on the classpath
 
 Provide-Capability: osgi.implementation;osgi.implementation="aries.jax-rs";version:Version="${Bundle-Version}"
+

--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -129,6 +129,21 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                
+                <executions>
+                    <execution>
+                        <id>java-9-plus</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <bndfile>bnd-java-9-plus.bnd</bndfile>
+                            <manifestPath>${project.build.outputDirectory}/META-INF/versions/9/OSGI-INF/MANIFEST.MF</manifestPath>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/jax-rs.whiteboard/pom.xml
+++ b/jax-rs.whiteboard/pom.xml
@@ -70,6 +70,27 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+      
+        <!-- Needed by the Whiteboard at runtime -->  
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.dynamic.framework.extension</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
+        
+        <!-- Needed by the Whiteboard to run on Java 9 + -->
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/jax-rs.whiteboard/src/main/java/org/apache/aries/jax/rs/whiteboard/activator/CxfJaxrsBundleActivator.java
+++ b/jax-rs.whiteboard/src/main/java/org/apache/aries/jax/rs/whiteboard/activator/CxfJaxrsBundleActivator.java
@@ -18,6 +18,7 @@
 package org.apache.aries.jax.rs.whiteboard.activator;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
@@ -69,15 +70,25 @@ import static org.osgi.service.http.whiteboard.HttpWhiteboardConstants.HTTP_WHIT
 @Header(name = Constants.BUNDLE_ACTIVATOR, value = "${@class}")
 public class CxfJaxrsBundleActivator implements BundleActivator {
 
-    public static final List<Class<?>> INTERNALLY_REQUIRED_CLASSES = Arrays.asList(
-        com.ctc.wstx.stax.WstxInputFactory.class,
-        com.sun.xml.bind.annotation.XmlLocation.class
-    );
+    public static final List<Class<?>> INTERNALLY_REQUIRED_CLASSES; 
 
     private static final Logger _log = LoggerFactory.getLogger(
         CxfJaxrsBundleActivator.class);
 
     static {
+    	Class<?> xmlLocation;
+    	try {
+    		xmlLocation = com.sun.xml.bind.annotation.XmlLocation.class;
+    	} catch (NoClassDefFoundError e) {
+    		// Swallow it
+    		xmlLocation = null;
+    	}
+    	
+    	Class<?> wstxInputFactory = com.ctc.wstx.stax.WstxInputFactory.class;
+    	
+    	INTERNALLY_REQUIRED_CLASSES = xmlLocation == null ? Collections.singletonList(wstxInputFactory) :
+    		Arrays.asList(wstxInputFactory, xmlLocation);
+    	
         RuntimeDelegate.setInstance(new RuntimeDelegateImpl());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <johnzon.version>1.2.11</johnzon.version>
         <jackson.version>2.12.3</jackson.version>
         <jaxb.version>2.3.3</jaxb.version>
+        <jaxws.version>2.3.3</jaxws.version>
         <jettison.version>1.4.1</jettison.version>
         <json.unit.assertj.version>2.25.0</json.unit.assertj.version>
         <junit.version>4.13.2</junit.version>
@@ -114,6 +115,16 @@
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>
                 <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
+                <version>${jaxws.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
@@ -673,55 +684,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>java-release-8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <properties>
-            </properties>
-        </profile>
-        <profile>
-            <id>java-release-9+</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <java.build.version>${java.specification.version}</java.build.version>
-                <maven.compiler.release>${java.build.version}</maven.compiler.release>
-                <maven.compiler.source>${java.build.version}</maven.compiler.source>
-                <maven.compiler.target>${java.build.version}</maven.compiler.target>
-            </properties>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>jakarta.xml.bind</groupId>
-                        <artifactId>jakarta.xml.bind-api</artifactId>
-                        <version>${jaxb.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>jakarta.xml.ws</groupId>
-                        <artifactId>jakarta.xml.ws-api</artifactId>
-                        <version>${jaxb.version}</version>
-                        <scope>runtime</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.xml.ws</groupId>
-                    <artifactId>jakarta.xml.ws-api</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 
     <reporting>
         <plugins>


### PR DESCRIPTION
Part of this change requires removing the Java 8 and 9+ profiles, which don't translate into the built pom and therefore leave unsatisfied dependencies.

Signed-off-by: Tim Ward <timothyjward@apache.org>