### PR TITLE
Fix JUnit dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,7 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>net.javacrumbs.json-unit</groupId>


### PR DESCRIPTION
org.apache.aries.jax.rs.whiteboard currently has a JUnit 4 dependency on compile scope.
So this results in issues if you depend on it in a project only using JUnit 5.

Due to this transitive dependency, openHAB contributors think they can use the `@Ignore` JUnit 4 annotation to disable test, but this annotation does not work when using JUnit 5.

See: https://github.com/openhab/openhab-addons/pull/11232

While I was at it, I also converted the few tests in this project to JUnit 5.

The org.apache.aries.component-dsl.component-dsl artifact has exactly the same issue, so I've excluded the junit dependency from it.