### PR TITLE
Replace JAX-RS API dependency with Geronimo spec to fix  ARIES-2124

### DIFF
--- a/jax-rs.features/src/main/feature/feature.xml
+++ b/jax-rs.features/src/main/feature/feature.xml
@@ -24,7 +24,7 @@
         <feature>cxf-specs</feature>
         <feature>cxf-jaxrs</feature>
         <feature>cxf-sse</feature>
-        <bundle dependency="true">mvn:org.apache.aries.spec/org.apache.aries.javax.jax.rs-api/1.0.1</bundle>
+        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jaxrs_2.1_spec/1.1</bundle>
         <bundle dependency="true">mvn:org.osgi/org.osgi.util.function/1.1.0</bundle>
         <bundle dependency="true">mvn:org.osgi/org.osgi.util.promise/1.1.0</bundle>
         <bundle dependency="true">mvn:org.osgi/org.osgi.service.jaxrs/1.0.0</bundle>


### PR DESCRIPTION
fixes [ARIES-2124](https://issues.apache.org/jira/browse/ARIES-2124)

The referenced bundle mvn:org.apache.aries.spec/org.apache.aries.javax.jax.rs-api/1.0.1 is corrupt and unmaintained. It was originally maintained in the aries-jax-rs-whiteboard repository but has been removed for some time now. Only this reference on the old version remains.

mvn:org.apache.geronimo.specs/geronimo-jaxrs_2.1_spec/1.1 works as a drop in replacement for me.

I'm not very proficient with Karaf features, so please review if this change needs additional work concerning upgrade paths for existing users that have the old bundle already deployed.